### PR TITLE
EnumNamespaces config option with list of namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+Пример конфига GenConfig.json
+
+{
+  "CsProject": "Declaration.csproj",
+  "Dll": "bin/Debug/net5.0/publish/Declaration.dll",
+  "DbModels": {
+    "Namespace": "MobileApi.Dal.Model",
+    "EnumNamespaces": [
+      "MobileApi.Dal.Common",
+      "Dex.CreditCardType.Resolver"
+    ],
+    "Path": "../MobileApi.Dal/Model/Generated",
+    "IsSnakeCase": true
+  },
+  "DbFluentFk": {
+    "Namespace": "MobileApi.Dal.Provider",
+    "Path": "../MobileApi.Dal/Provider/Generated/DbFluentFkProvider.g.cs"
+  },
+  "DbFluentEnum": {
+    "Namespace": "MobileApi.Dal.Provider",
+    "Path": "../MobileApi.Dal/Provider/Generated/DbFluentEnumProvider.g.cs"
+  },
+  "DbFluentIndex": {
+    "Namespace": "MobileApi.Dal.Provider",
+    "Path": "../MobileApi.Dal/Provider/Generated/DbFluentIndexProvider.g.cs"
+  },
+  "Dto": {
+    "Namespace": "MobileApi.Dto",
+    "Path": "../MobileApi.Dto/Generated"
+  }
+}

--- a/src/Dex.DalGenerator/Generator/DbEntitiesGenerator.cs
+++ b/src/Dex.DalGenerator/Generator/DbEntitiesGenerator.cs
@@ -16,19 +16,19 @@ namespace Dex.DalGenerator.Generator
         
         private readonly string _ns;
         
-        private readonly string _enumNamespace;
+        private readonly string[] _enumNamespaces;
         private readonly bool _isSnakeCase;
 
         public DbEntitiesGenerator(
             IEntityModel[] entities, 
             Relation[] relations,
             string modelNamespace,
-            string enumNamespace, 
+            string[] enumNamespaces, 
             bool isSnakeCase)
         {
             _relations = relations ?? throw new ArgumentNullException(nameof(relations));
             _ns = modelNamespace;
-            _enumNamespace = enumNamespace;
+            _enumNamespaces = enumNamespaces;
             _isSnakeCase = isSnakeCase;
             _entities = entities ?? throw new ArgumentNullException(nameof(entities));
         }
@@ -45,7 +45,7 @@ namespace Dex.DalGenerator.Generator
             foreach (var entityModel in _entities)
             {
                 var relations = _relations.Where(r => r.EntityName == entityModel.Name).ToArray();
-                new DbEntityGenerator(entityModel, relations, _ns, _enumNamespace, _isSnakeCase)
+                new DbEntityGenerator(entityModel, relations, _ns, _enumNamespaces, _isSnakeCase)
                     .WriteToFile(Path.Combine(folderPath, $"{entityModel.Name}.g.cs"));
                 // todo зачем это делать в цикле?
                 files = files.Where(f => f.Name != entityModel.Name).ToArray();

--- a/src/Dex.DalGenerator/Generator/DtoEntitiesGenerator.cs
+++ b/src/Dex.DalGenerator/Generator/DtoEntitiesGenerator.cs
@@ -12,14 +12,14 @@ namespace Dex.DalGenerator.Generator
     {
         private readonly IEntityModel[] _entities;
         private readonly string _namespace;
-        private readonly string _enumNamespace;
+        private readonly string[] _enumNamespaces;
 
 
-        public DtoEntitiesGenerator(IEntityModel[] entities, string @namespace, string enumNamespace)
+        public DtoEntitiesGenerator(IEntityModel[] entities, string @namespace, string[] enumNamespaces)
         {
             _entities = entities ?? throw new ArgumentNullException(nameof(entities));
             _namespace = @namespace;
-            _enumNamespace = enumNamespace;
+            _enumNamespaces = enumNamespaces;
         }
 
         public void Generate(string folderPath)
@@ -29,7 +29,7 @@ namespace Dex.DalGenerator.Generator
 
             foreach (var entityModel in _entities)
             {
-                new DtoEntityGenerator(entityModel, _namespace, _enumNamespace, folderPath)
+                new DtoEntityGenerator(entityModel, _namespace, _enumNamespaces, folderPath)
                     .WriteToFile(Path.Combine(folderPath, $"{entityModel.Name}.g.cs"));
             }
         }

--- a/src/Dex.DalGenerator/Program.cs
+++ b/src/Dex.DalGenerator/Program.cs
@@ -73,10 +73,10 @@ namespace Dex.DalGenerator
             var relations = entityModels.CollectRelations();
 
             var modelNamespace = setting.DbModels.Namespace;
-            var enumNamespace = setting.DbModels.EnumNamespace;
+            var enumNamespaces = setting.DbModels.EnumNamespaces ?? new[] { setting.DbModels.EnumNamespace };
             var isSnakeCase = setting.DbModels.IsSnakeCase;
             var dbEntitiesGenerator =
-                new DbEntitiesGenerator(entityModels, relations, modelNamespace, enumNamespace, isSnakeCase);
+                new DbEntitiesGenerator(entityModels, relations, modelNamespace, enumNamespaces, isSnakeCase);
 
             var folderPath = setting.DbModels.Path;
             Directory.CreateDirectory(folderPath);
@@ -102,7 +102,7 @@ namespace Dex.DalGenerator
             {
                 Log("Generate enum by fluent syntax");
                 var ns = setting.DbFluentEnum.Namespace;
-                var enumFluentGenerator = new EnumFluentGenerator(entityModels, ns, enumNamespace);
+                var enumFluentGenerator = new EnumFluentGenerator(entityModels, ns, enumNamespaces);
                 enumFluentGenerator.WriteToFile(setting.DbFluentEnum.Path);
             }
 
@@ -117,7 +117,7 @@ namespace Dex.DalGenerator
 
                 Log("Generate dtos");
                 var ns = setting.Dto.Namespace;
-                var dtoEntitiesGenerator = new DtoEntitiesGenerator(models, ns, enumNamespace);
+                var dtoEntitiesGenerator = new DtoEntitiesGenerator(models, ns, enumNamespaces);
                 folderPath = setting.Dto.Path;
                 Directory.CreateDirectory(folderPath);
                 dtoEntitiesGenerator.Generate(folderPath);

--- a/src/Dex.DalGenerator/Program.cs
+++ b/src/Dex.DalGenerator/Program.cs
@@ -73,7 +73,7 @@ namespace Dex.DalGenerator
             var relations = entityModels.CollectRelations();
 
             var modelNamespace = setting.DbModels.Namespace;
-            var enumNamespaces = setting.DbModels.EnumNamespaces ?? new[] { setting.DbModels.EnumNamespace };
+            var enumNamespaces = setting.DbModels.EnumNamespaces;
             var isSnakeCase = setting.DbModels.IsSnakeCase;
             var dbEntitiesGenerator =
                 new DbEntitiesGenerator(entityModels, relations, modelNamespace, enumNamespaces, isSnakeCase);

--- a/src/Dex.DalGenerator/Settings/GenElement.cs
+++ b/src/Dex.DalGenerator/Settings/GenElement.cs
@@ -4,8 +4,6 @@ namespace Dex.DalGenerator.Settings
     {
         public string Namespace { get; set; }
 
-        public string EnumNamespace { get; set; }
-
         public string[] EnumNamespaces { get; set; }
 
         public string Path { get; set; }

--- a/src/Dex.DalGenerator/Settings/GenElement.cs
+++ b/src/Dex.DalGenerator/Settings/GenElement.cs
@@ -5,7 +5,9 @@ namespace Dex.DalGenerator.Settings
         public string Namespace { get; set; }
 
         public string EnumNamespace { get; set; }
-        
+
+        public string[] EnumNamespaces { get; set; }
+
         public string Path { get; set; }
     }
 }

--- a/src/Dex.DalGenerator/Templates/Base/DbEntityGenerator.cs
+++ b/src/Dex.DalGenerator/Templates/Base/DbEntityGenerator.cs
@@ -14,16 +14,16 @@ namespace Dex.DalGenerator.Templates
     {
         public Relation[] Relations { get; }
         public string Namespace { get; }
-        public string EnumNamespace { get; }
+        public string[] EnumNamespaces { get; }
         public bool IsSnakeCase { get; }
         public IEntityModel Entity { get; }
 
-        public DbEntityGenerator(IEntityModel model, Relation[] relations, string @namespace, string enumNamespace,
+        public DbEntityGenerator(IEntityModel model, Relation[] relations, string @namespace, string[] enumNamespaces,
             bool isSnakeCase)
         {
             Relations = relations;
             Namespace = @namespace;
-            EnumNamespace = enumNamespace;
+            EnumNamespaces = enumNamespaces;
             IsSnakeCase = isSnakeCase;
 
             Entity = model ?? throw new ArgumentNullException(nameof(model));

--- a/src/Dex.DalGenerator/Templates/Base/DtoEntityGenerator.cs
+++ b/src/Dex.DalGenerator/Templates/Base/DtoEntityGenerator.cs
@@ -12,14 +12,14 @@ namespace Dex.DalGenerator.Templates
         private readonly string _customSourceTypeName;
         public IEntityModel Entity { get; }
         private readonly string _namespace;
-        private readonly string _enumNamespace;
+        private readonly string[] _enumNamespaces;
 
-        public DtoEntityGenerator(IEntityModel model, string @namespace, string enumNamespace,
+        public DtoEntityGenerator(IEntityModel model, string @namespace, string[] enumNamespaces,
             string customSourceTypeName = null)
         {
             _customSourceTypeName = customSourceTypeName;
             _namespace = @namespace;
-            _enumNamespace = enumNamespace;
+            _enumNamespaces = enumNamespaces;
             Entity = model ?? throw new ArgumentNullException(nameof(model));
         }
 

--- a/src/Dex.DalGenerator/Templates/Base/EnumFluentGenerator.cs
+++ b/src/Dex.DalGenerator/Templates/Base/EnumFluentGenerator.cs
@@ -11,13 +11,13 @@ namespace Dex.DalGenerator.Templates
     {
         private readonly IReadOnlyCollection<Type> _enums;
         private readonly string _namespace;
-        private readonly string _enumNamespace;
+        private readonly string[] _enumNamespaces;
 
-        public EnumFluentGenerator(IEntityModel[] entities, string @namespace, string enumNamespace)
+        public EnumFluentGenerator(IEntityModel[] entities, string @namespace, string[] enumNamespaces)
         {
             if (entities == null) throw new ArgumentNullException(nameof(entities));
             _namespace = @namespace;
-            _enumNamespace = enumNamespace;
+            _enumNamespaces = enumNamespaces;
             _enums = entities
                 .SelectMany(m => m.Properties.Values, (m, p) => p.PropertyType)
                 .Where(p => p.BaseType == typeof(Enum)).Distinct()

--- a/src/Dex.DalGenerator/Templates/DbEntityGenerator.cs
+++ b/src/Dex.DalGenerator/Templates/DbEntityGenerator.cs
@@ -17,7 +17,7 @@ namespace Dex.DalGenerator.Templates
     /// Class to produce the template output
     /// </summary>
     
-    #line 1 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
+    #line 1 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.TextTemplating", "16.0.0.0")]
     public partial class DbEntityGenerator : DbEntityGeneratorBase
     {
@@ -28,7 +28,7 @@ namespace Dex.DalGenerator.Templates
         public virtual string TransformText()
         {
             
-            #line 1 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
+            #line 1 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
 
     // ReSharper disable RedundantNameQualifier
 
@@ -36,23 +36,42 @@ namespace Dex.DalGenerator.Templates
             #line default
             #line hidden
             this.Write("using System;\r\nusing System.ComponentModel.DataAnnotations;\r\nusing System.Compone" +
-                    "ntModel.DataAnnotations.Schema;\r\nusing ");
+                    "ntModel.DataAnnotations.Schema;\r\n");
             
-            #line 10 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(EnumNamespace));
+            #line 10 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
+
+foreach (var enumNamespace in EnumNamespaces)
+{
+
             
             #line default
             #line hidden
-            this.Write(";\r\nusing Dex.Ef.Contracts.Entities;\r\n\r\nnamespace ");
+            this.Write("using ");
             
-            #line 13 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
+            #line 14 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(enumNamespace));
+            
+            #line default
+            #line hidden
+            this.Write(";\r\n");
+            
+            #line 15 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
+
+}
+
+            
+            #line default
+            #line hidden
+            this.Write("using Dex.Ef.Contracts.Entities;\r\n\r\nnamespace ");
+            
+            #line 20 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Namespace));
             
             #line default
             #line hidden
             this.Write("\r\n{\r\n");
             
-            #line 15 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
+            #line 22 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
 
 	string implements = Entity.IsRootType ? " : " + string.Join(", ", Entity.Implements.Select(i=>i.GetFriendlyName())) : string.Empty;
 
@@ -61,27 +80,27 @@ namespace Dex.DalGenerator.Templates
             #line hidden
             this.Write("\t[Table(\"");
             
-            #line 18 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
+            #line 25 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(GetTableName(Entity)));
             
             #line default
             #line hidden
             this.Write("\")]\r\n\tpublic partial class ");
             
-            #line 19 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
+            #line 26 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Entity.Name));
             
             #line default
             #line hidden
             
-            #line 19 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
+            #line 26 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(implements));
             
             #line default
             #line hidden
             this.Write("\r\n\t{\r\n");
             
-            #line 21 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
+            #line 28 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
 
 foreach(var prop in Entity.Properties.Values)
 {
@@ -91,28 +110,28 @@ foreach(var prop in Entity.Properties.Values)
             #line hidden
             this.Write("\r\n\t\t");
             
-            #line 26 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
+            #line 33 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(GetAttributes(prop)));
             
             #line default
             #line hidden
             this.Write("\r\n\t\tpublic ");
             
-            #line 27 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
+            #line 34 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(prop.PropertyType.GetFriendlyName() + (prop.IsCollection? "[]" : "")));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 27 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
+            #line 34 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(prop.Name));
             
             #line default
             #line hidden
             this.Write(" { get; set; }\r\n");
             
-            #line 28 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
+            #line 35 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
 
 }
 
@@ -132,14 +151,14 @@ foreach(var relation in Relations)
             #line hidden
             this.Write("\t\t[ForeignKey(nameof(");
             
-            #line 42 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
+            #line 49 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(relation.KeyPropertyName));
             
             #line default
             #line hidden
             this.Write("))]\r\n");
             
-            #line 43 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
+            #line 50 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
 	
 	}
 
@@ -148,21 +167,21 @@ foreach(var relation in Relations)
             #line hidden
             this.Write("\t\tpublic ");
             
-            #line 46 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
+            #line 53 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(typeName));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 46 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
+            #line 53 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(relation.PropertyName));
             
             #line default
             #line hidden
             this.Write(" { get; set; }\r\n");
             
-            #line 47 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
+            #line 54 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DbEntityGenerator.tt"
 
 }
 

--- a/src/Dex.DalGenerator/Templates/DbEntityGenerator.tt
+++ b/src/Dex.DalGenerator/Templates/DbEntityGenerator.tt
@@ -7,7 +7,14 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using <#= EnumNamespace #>;
+<#
+foreach (var enumNamespace in EnumNamespaces)
+{
+#>
+using <#= enumNamespace #>;
+<#
+}
+#>
 using Dex.Ef.Contracts.Entities;
 
 namespace <#=Namespace#>

--- a/src/Dex.DalGenerator/Templates/DtoEntityGenerator.cs
+++ b/src/Dex.DalGenerator/Templates/DtoEntityGenerator.cs
@@ -17,7 +17,7 @@ namespace Dex.DalGenerator.Templates
     /// Class to produce the template output
     /// </summary>
     
-    #line 1 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+    #line 1 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.TextTemplating", "16.0.0.0")]
     public partial class DtoEntityGenerator : DtoEntityGeneratorBase
     {
@@ -28,44 +28,63 @@ namespace Dex.DalGenerator.Templates
         public virtual string TransformText()
         {
             
-            #line 1 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+            #line 1 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
 
     // ReSharper disable RedundantNameQualifier
 
             
             #line default
             #line hidden
-            this.Write("using System;\r\nusing System.ComponentModel.DataAnnotations;\r\nusing ");
+            this.Write("using System;\r\nusing System.ComponentModel.DataAnnotations;\r\n");
             
-            #line 9 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(_enumNamespace));
+            #line 9 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+
+foreach (var enumNamespace in _enumNamespaces)
+{
+
             
             #line default
             #line hidden
-            this.Write(";\r\n\r\nnamespace ");
+            this.Write("using ");
             
-            #line 11 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+            #line 13 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(enumNamespace));
+            
+            #line default
+            #line hidden
+            this.Write(";\r\n");
+            
+            #line 14 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+
+}
+
+            
+            #line default
+            #line hidden
+            this.Write("\r\nnamespace ");
+            
+            #line 18 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_namespace));
             
             #line default
             #line hidden
             this.Write("\r\n{\r\n\tpublic partial class ");
             
-            #line 13 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+            #line 20 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Entity.Name));
             
             #line default
             #line hidden
             this.Write(": ");
             
-            #line 13 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+            #line 20 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(GetSourceTypeName()));
             
             #line default
             #line hidden
             this.Write("\r\n\t{\r\n");
             
-            #line 15 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+            #line 22 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
 
 		foreach(var prop in Entity.Properties.Values)
 		{
@@ -77,7 +96,7 @@ namespace Dex.DalGenerator.Templates
             #line hidden
             this.Write("\t\t[Required]\r\n");
             
-            #line 22 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+            #line 29 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
 
             }
 
@@ -86,27 +105,27 @@ namespace Dex.DalGenerator.Templates
             #line hidden
             this.Write("        public ");
             
-            #line 25 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+            #line 32 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(GetFriendlyName(prop)));
             
             #line default
             #line hidden
             
-            #line 25 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+            #line 32 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(prop.IsCollection ? "[]" : ""));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 25 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+            #line 32 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(prop.Name));
             
             #line default
             #line hidden
             this.Write(" { get; set; }\r\n");
             
-            #line 26 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+            #line 33 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
  
         }
 		foreach(var prop in Entity.References.Values)
@@ -119,7 +138,7 @@ namespace Dex.DalGenerator.Templates
             #line hidden
             this.Write("\t\t[Required]\r\n");
             
-            #line 34 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+            #line 41 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
 
             }
 
@@ -128,27 +147,27 @@ namespace Dex.DalGenerator.Templates
             #line hidden
             this.Write("        public ");
             
-            #line 37 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+            #line 44 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(prop.TargetEntity.Name));
             
             #line default
             #line hidden
             
-            #line 37 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+            #line 44 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(prop.IsCollection ? "[]" : ""));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 37 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+            #line 44 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(prop.Name));
             
             #line default
             #line hidden
             this.Write(" { get; set; }\r\n");
             
-            #line 38 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+            #line 45 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
 
             if(prop.HasAttribute<RequiredAttribute>())
             {
@@ -158,7 +177,7 @@ namespace Dex.DalGenerator.Templates
             #line hidden
             this.Write("\t\t[Required]\r\n");
             
-            #line 43 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+            #line 50 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
 
             }
 
@@ -167,41 +186,41 @@ namespace Dex.DalGenerator.Templates
             #line hidden
             this.Write("\t\t");
             
-            #line 46 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+            #line 53 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(prop.TargetEntity.SourceType.GetFriendlyName()));
             
             #line default
             #line hidden
             
-            #line 46 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+            #line 53 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(prop.IsCollection ? "[]" : ""));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 46 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+            #line 53 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(GetSourceTypeName()));
             
             #line default
             #line hidden
             this.Write(".");
             
-            #line 46 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+            #line 53 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(prop.Name));
             
             #line default
             #line hidden
             this.Write(" => this.");
             
-            #line 46 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+            #line 53 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(prop.Name));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 47 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
+            #line 54 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\DtoEntityGenerator.tt"
  
         }
 

--- a/src/Dex.DalGenerator/Templates/DtoEntityGenerator.tt
+++ b/src/Dex.DalGenerator/Templates/DtoEntityGenerator.tt
@@ -6,7 +6,14 @@
 <#@ import namespace="Dex.DalGenerator.Core.Extensions" #>
 using System;
 using System.ComponentModel.DataAnnotations;
-using <#= _enumNamespace #>;
+<#
+foreach (var enumNamespace in _enumNamespaces)
+{
+#>
+using <#= enumNamespace #>;
+<#
+}
+#>
 
 namespace <#= _namespace #>
 {

--- a/src/Dex.DalGenerator/Templates/EnumFluentGenerator.cs
+++ b/src/Dex.DalGenerator/Templates/EnumFluentGenerator.cs
@@ -15,7 +15,7 @@ namespace Dex.DalGenerator.Templates
     /// Class to produce the template output
     /// </summary>
     
-    #line 1 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\EnumFluentGenerator.tt"
+    #line 1 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\EnumFluentGenerator.tt"
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.TextTemplating", "16.0.0.0")]
     public partial class EnumFluentGenerator : EnumFluentGeneratorBase
     {
@@ -25,17 +25,35 @@ namespace Dex.DalGenerator.Templates
         /// </summary>
         public virtual string TransformText()
         {
-            this.Write("using ");
             
-            #line 2 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\EnumFluentGenerator.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(_enumNamespace));
+            #line 2 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\EnumFluentGenerator.tt"
+
+foreach (var enumNamespace in _enumNamespaces)
+{
+
             
             #line default
             #line hidden
-            this.Write(";\r\nusing Microsoft.EntityFrameworkCore;\r\nusing Npgsql;\r\nusing System.Linq;\r\nusing" +
-                    " System.Text.RegularExpressions;\r\nusing System;\r\n\r\nnamespace ");
+            this.Write("using ");
             
-            #line 9 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\EnumFluentGenerator.tt"
+            #line 6 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\EnumFluentGenerator.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(enumNamespace));
+            
+            #line default
+            #line hidden
+            this.Write(";\r\n");
+            
+            #line 7 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\EnumFluentGenerator.tt"
+
+}
+
+            
+            #line default
+            #line hidden
+            this.Write("using Microsoft.EntityFrameworkCore;\r\nusing Npgsql;\r\nusing System.Linq;\r\nusing Sy" +
+                    "stem.Text.RegularExpressions;\r\nusing System;\r\n\r\nnamespace ");
+            
+            #line 16 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\EnumFluentGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(_namespace));
             
             #line default
@@ -43,7 +61,7 @@ namespace Dex.DalGenerator.Templates
             this.Write("\r\n{\r\n    internal static class EnumFluentDbProvider\r\n    {\r\n\t    public static vo" +
                     "id MapEnum()\r\n\t\t{\r\n");
             
-            #line 15 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\EnumFluentGenerator.tt"
+            #line 22 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\EnumFluentGenerator.tt"
 
 	foreach (var @enum in _enums)
 	{
@@ -54,21 +72,21 @@ namespace Dex.DalGenerator.Templates
             #line hidden
             this.Write("            NpgsqlConnection.GlobalTypeMapper.MapEnum<");
             
-            #line 20 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\EnumFluentGenerator.tt"
+            #line 27 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\EnumFluentGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(enumName));
             
             #line default
             #line hidden
             this.Write(">(nameof(");
             
-            #line 20 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\EnumFluentGenerator.tt"
+            #line 27 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\EnumFluentGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(enumName));
             
             #line default
             #line hidden
             this.Write(").ToLower());\r\n");
             
-            #line 21 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\EnumFluentGenerator.tt"
+            #line 28 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\EnumFluentGenerator.tt"
 
 	}
 
@@ -89,7 +107,7 @@ namespace Dex.DalGenerator.Templates
         {
 ");
             
-            #line 36 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\EnumFluentGenerator.tt"
+            #line 43 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\EnumFluentGenerator.tt"
 
     foreach (var @enum in _enums)
 	{
@@ -100,21 +118,21 @@ namespace Dex.DalGenerator.Templates
             #line hidden
             this.Write("            builder.HasPostgresEnum(nameof(");
             
-            #line 41 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\EnumFluentGenerator.tt"
+            #line 48 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\EnumFluentGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(enumName));
             
             #line default
             #line hidden
             this.Write(").ToLower(), GetNames(typeof(");
             
-            #line 41 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\EnumFluentGenerator.tt"
+            #line 48 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\EnumFluentGenerator.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(enumName));
             
             #line default
             #line hidden
             this.Write(")));\r\n\r\n");
             
-            #line 43 "D:\Projects\Dex\DomainGenerator\src\Dex.DalGenerator\Templates\EnumFluentGenerator.tt"
+            #line 50 "D:\Projects\GorodPay\Dex.DalGenerator\src\Dex.DalGenerator\Templates\EnumFluentGenerator.tt"
 
 	}
 

--- a/src/Dex.DalGenerator/Templates/EnumFluentGenerator.tt
+++ b/src/Dex.DalGenerator/Templates/EnumFluentGenerator.tt
@@ -1,5 +1,12 @@
 ﻿<#@ template debug="false" hostspecific="false" language="C#" #>
-using <#= _enumNamespace #>;
+<#
+foreach (var enumNamespace in _enumNamespaces)
+{
+#>
+using <#= enumNamespace #>;
+<#
+}
+#>
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
 using System.Linq;


### PR DESCRIPTION
Add EnumNamespaces in configs with list of enum namespaces as extension of current EnumNamespace. Current EnumNamespace still available for back compatibility purpose. In case of existing both EnumNamespace and EnumNamespaces only EnumNamespaces will be used.